### PR TITLE
Change DevKitPro workflow to be courteous and use cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,22 +28,13 @@ jobs:
   build_modern:
     name: Build ROM with DevKitPro
     runs-on: ubuntu-latest
+    container: devkitpro/devkitarm
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          sudo apt-get install apt-transport-https
-          if ! [ -f /usr/local/share/keyring/devkitpro-pub.gpg ]; then
-            sudo mkdir -p /usr/local/share/keyring/
-            sudo wget -O /usr/local/share/keyring/devkitpro-pub.gpg https://apt.devkitpro.org/devkitpro-pub.gpg
-          fi
-          if ! [ -f /etc/apt/sources.list.d/devkitpro.list ]; then
-            sudo bash -c 'echo "deb [signed-by=/usr/local/share/keyring/devkitpro-pub.gpg] https://apt.devkitpro.org stable main" > /etc/apt/sources.list.d/devkitpro.list'
-          fi
-          sudo apt-get update
-          sudo apt-get install devkitpro-pacman
-          sudo dkp-pacman -S --noconfirm 3ds-dev
+          apt update
+          apt install -y build-essential libpng-dev
       - name: Build ROM
         run: |
-          source /etc/profile.d/devkit-env.sh
           make -j$(nproc) modern debug=1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This upgrades the DevKitPro workflow to use a Docker container that has all the 3ds-dev toolchain deps pre-installed.


## Description
<!--- Describe your changes in detail -->
The runner I originally wrote would randomly fail due to network conditions -- turns out this is a rate limiter because the DevKitPro guys have limited bandwidth. They suggest to all developers to use this Docker container set up I've used here to save them the money, and it also makes the build more reliable.

## **Discord contact info**
`luigi___`
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->