### PR TITLE
Simplify save upgrade code and record v1 in own header

### DIFF
--- a/src/data/old_saves/save.v0.h
+++ b/src/data/old_saves/save.v0.h
@@ -1,3 +1,8 @@
+/**
+ * @author Isaac Aronson (Discord: @luigi___) (github.com/aronson)
+ * @details Records the original save file format structures and provides an upgrade method for them to v1.
+ * original code by tustin2121
+ */
 #ifndef MOEMON_EMERALD_SAVE_V0_H
 #define MOEMON_EMERALD_SAVE_V0_H
 
@@ -5,84 +10,82 @@
 #include "save.h"
 #include "malloc.h"
 
-struct ObjectEvent_v0
-{
-    /*0x00*/ u32 active:1;
-    u32 singleMovementActive:1;
-    u32 triggerGroundEffectsOnMove:1;
-    u32 triggerGroundEffectsOnStop:1;
-    u32 disableCoveringGroundEffects:1;
-    u32 landingJump:1;
-    u32 heldMovementActive:1;
-    u32 heldMovementFinished:1;
-    /*0x01*/ u32 frozen:1;
-    u32 facingDirectionLocked:1;
-    u32 disableAnim:1;
-    u32 enableAnim:1;
-    u32 inanimate:1;
-    u32 invisible:1;
-    u32 offScreen:1;
-    u32 trackedByCamera:1;
-    /*0x02*/ u32 isPlayer:1;
-    u32 hasReflection:1;
-    u32 inShortGrass:1;
-    u32 inShallowFlowingWater:1;
-    u32 inSandPile:1;
-    u32 inHotSprings:1;
-    u32 noShadow:1;
-    u32 spriteAnimPausedBackup:1;
-    /*0x03*/ u32 spriteAffineAnimPausedBackup:1;
-    u32 disableJumpLandingGroundEffect:1;
-    u32 fixedPriority:1;
-    u32 hideReflection:1;
+struct ObjectEvent_v0 {
+    u32 active: 1;
+    u32 singleMovementActive: 1;
+    u32 triggerGroundEffectsOnMove: 1;
+    u32 triggerGroundEffectsOnStop: 1;
+    u32 disableCoveringGroundEffects: 1;
+    u32 landingJump: 1;
+    u32 heldMovementActive: 1;
+    u32 heldMovementFinished: 1;
+    u32 frozen: 1;
+    u32 facingDirectionLocked: 1;
+    u32 disableAnim: 1;
+    u32 enableAnim: 1;
+    u32 inanimate: 1;
+    u32 invisible: 1;
+    u32 offScreen: 1;
+    u32 trackedByCamera: 1;
+    u32 isPlayer: 1;
+    u32 hasReflection: 1;
+    u32 inShortGrass: 1;
+    u32 inShallowFlowingWater: 1;
+    u32 inSandPile: 1;
+    u32 inHotSprings: 1;
+    u32 noShadow: 1;
+    u32 spriteAnimPausedBackup: 1;
+    u32 spriteAffineAnimPausedBackup: 1;
+    u32 disableJumpLandingGroundEffect: 1;
+    u32 fixedPriority: 1;
+    u32 hideReflection: 1;
     //u32 padding:4;
-    /*0x04*/ u8 spriteId;
-    /*0x05*/ u8 graphicsId;
-    /*0x06*/ u8 movementType;
-    /*0x07*/ u8 trainerType;
-    /*0x08*/ u8 localId;
-    /*0x09*/ u8 mapNum;
-    /*0x0A*/ u8 mapGroup;
-    /*0x0B*/ u8 currentElevation:4;
-    u8 previousElevation:4;
-    /*0x0C*/ struct Coords16 initialCoords;
-    /*0x10*/ struct Coords16 currentCoords;
-    /*0x14*/ struct Coords16 previousCoords;
-    /*0x18*/ u16 facingDirection:4; // current direction?
-    u16 movementDirection:4;
-    u16 rangeX:4;
-    u16 rangeY:4;
-    /*0x1A*/ u8 fieldEffectSpriteId;
-    /*0x1B*/ u8 warpArrowSpriteId;
-    /*0x1C*/ u8 movementActionId;
-    /*0x1D*/ u8 trainerRange_berryTreeId;
-    /*0x1E*/ u8 currentMetatileBehavior;
-    /*0x1F*/ u8 previousMetatileBehavior;
-    /*0x20*/ u8 previousMovementDirection;
-    /*0x21*/ u8 directionSequenceIndex;
-    /*0x22*/ union __attribute__((packed)) {
+    u8 spriteId;
+    u8 graphicsId;
+    u8 movementType;
+    u8 trainerType;
+    u8 localId;
+    u8 mapNum;
+    u8 mapGroup;
+    u8 currentElevation: 4;
+    u8 previousElevation: 4;
+    struct Coords16 initialCoords;
+    struct Coords16 currentCoords;
+    struct Coords16 previousCoords;
+    u16 facingDirection: 4; // current direction?
+    u16 movementDirection: 4;
+    u16 rangeX: 4;
+    u16 rangeY: 4;
+    u8 fieldEffectSpriteId;
+    u8 warpArrowSpriteId;
+    u8 movementActionId;
+    u8 trainerRange_berryTreeId;
+    u8 currentMetatileBehavior;
+    u8 previousMetatileBehavior;
+    u8 previousMovementDirection;
+    u8 directionSequenceIndex;
+    union __attribute__((packed)) {
         u8 playerCopyableMovement; // COPY_MOVE_*
         struct __attribute__((packed)) {
-            u16 species:10; // 11 bits; 1024 species
-            u16 form:5; // Used for Deoxys, Unown, etc
-            u16 shiny:1;
+            u16 species: 10; // 11 bits; 1024 species
+            u16 form: 5; // Used for Deoxys, Unown, etc
+            u16 shiny: 1;
         } mon;
         u16 asU16;
     } extra;
-    /*size = 0x24*/
 };
 
 struct SaveBlock2_v0 {
-    /*0x00*/ u8 playerName[7 + 1];
-    /*0x08*/ u8 playerGender; // MALE, FEMALE
-    /*0x09*/ u8 specialSaveWarpFlags;
-    /*0x0A*/ u8 playerTrainerId[4];
-    /*0x0E*/ u16 playTimeHours;
-    /*0x10*/ u8 playTimeMinutes;
-    /*0x11*/ u8 playTimeSeconds;
-    /*0x12*/ u8 playTimeVBlanks;
-    /*0x13*/ u8 optionsButtonMode;  // OPTIONS_BUTTON_MODE_[NORMAL/LR/L_EQUALS_A]
-    /*0x14*/ u16 optionsTextSpeed: 3; // OPTIONS_TEXT_SPEED_[SLOW/MID/FAST]
+    u8 playerName[7 + 1];
+    u8 playerGender; // MALE, FEMALE
+    u8 specialSaveWarpFlags;
+    u8 playerTrainerId[4];
+    u16 playTimeHours;
+    u8 playTimeMinutes;
+    u8 playTimeSeconds;
+    u8 playTimeVBlanks;
+    u8 optionsButtonMode;  // OPTIONS_BUTTON_MODE_[NORMAL/LR/L_EQUALS_A]
+    u16 optionsTextSpeed: 3; // OPTIONS_TEXT_SPEED_[SLOW/MID/FAST]
     u16 optionsWindowFrameType: 5; // Specifies one of the 20 decorative borders for text boxes
     u16 optionsSound: 1; // OPTIONS_SOUND_[MONO/STEREO]
     u16 optionsBattleStyle: 1; // OPTIONS_BATTLE_STYLE_[SHIFT/SET]
@@ -90,116 +93,117 @@ struct SaveBlock2_v0 {
     u16 regionMapZoom: 1; // whether the map is zoomed in
     //u16 padding1:4;
     //u16 padding2;
-    /*0x18*/ struct Pokedex pokedex;
-    /*0x90*/ u8 filler_90[0x8];
-    /*0x98*/ struct Time localTimeOffset;
-    /*0xA0*/ struct Time lastBerryTreeUpdate;
-    /*0xA8*/ u32 gcnLinkFlags; // Read by Pokemon Colosseum/XD
-    /*0xAC*/ u32 encryptionKey;
-    /*0xB0*/ struct PlayersApprentice playerApprentice;
-    /*0xDC*/ struct Apprentice apprentices[2];   //272 bytes
-    /*0x1EC*/ struct BerryCrush berryCrush;
-    /*0x1FC*/ struct PokemonJumpRecords pokeJump;
-    /*0x20C*/ struct BerryPickingResults berryPick;
-    /*0x21C*/ struct RankingHall1P hallRecords1P[9][2][3]; // From record mixing.
-    /*0x57C*/ struct RankingHall2P hallRecords2P[2][3]; // From record mixing.
-    /*0x624*/ u16 contestLinkResults[5][4];
-    /*0x64C*/ struct BattleFrontier frontier;
-}; // sizeof=0xF2C
+    struct Pokedex pokedex;
+    u8 filler_90[0x8];
+    struct Time localTimeOffset;
+    struct Time lastBerryTreeUpdate;
+    u32 gcnLinkFlags; // Read by Pokemon Colosseum/XD
+    u32 encryptionKey;
+    struct PlayersApprentice playerApprentice;
+    struct Apprentice apprentices[2];   //272 bytes
+    struct BerryCrush berryCrush;
+    struct PokemonJumpRecords pokeJump;
+    struct BerryPickingResults berryPick;
+    struct RankingHall1P hallRecords1P[9][2][3]; // From record mixing.
+    struct RankingHall2P hallRecords2P[2][3]; // From record mixing.
+    u16 contestLinkResults[5][4];
+    struct BattleFrontier frontier;
+};
 
 struct SaveBlock1_v0 {
-    /*0x00*/ struct Coords16 pos;
-    /*0x04*/ struct WarpData location;
-    /*0x0C*/ struct WarpData continueGameWarp;
-    /*0x14*/ struct WarpData dynamicWarp;
-    /*0x1C*/ struct WarpData lastHealLocation; // used by white-out and teleport
-    /*0x24*/ struct WarpData escapeWarp; // used by Dig and Escape Rope
-    /*0x2C*/ u16 savedMusic;
-    /*0x2E*/ u8 weather;
-    /*0x2F*/ u8 weatherCycleStage;
-    /*0x30*/ u8 flashLevel;
-    /*0x31*/ //u8 padding1;
-    /*0x32*/ u16 mapLayoutId;
-    /*0x34*/ u16 mapView[0x100];
-    /*0x234*/ u8 playerPartyCount;
-    /*0x235*/ //u8 padding2[3];
-    /*0x238*/ struct Pokemon playerParty[6];
-    /*0x490*/ u32 money;
-    /*0x494*/ u16 coins;
-    /*0x496*/ u16 registeredItem; // registered for use with SELECT button
-    /*0x498*/ struct ItemSlot pcItems[50];
-    /*0x560*/ struct ItemSlot bagPocket_Items[30];
-    /*0x5D8*/ struct ItemSlot bagPocket_KeyItems[30];
-    /*0x650*/ struct ItemSlot bagPocket_PokeBalls[16];
-    /*0x690*/ struct ItemSlot bagPocket_TMHM[64];
-    /*0x790*/ struct ItemSlot bagPocket_Berries[46];
-    /*0x848*/ struct Pokeblock pokeblocks[40];
-    /*0x988*/ u8 seen1[52];   //52 bytes
-    /*0x9BC*/ u16 berryBlenderRecords[3];
-    /*0x9C2*/ u8 unused_9C2[6];
-    /*0x9C8*/ u16 trainerRematchStepCounter;    //104 bytes
-    /*0x9CA*/ u8 trainerRematches[100];
-    /*0xA2E*/ //u8 padding3[2];
-    /*0xA30*/ struct ObjectEvent_v0 objectEvents[16];
-    /*0xC70*/ struct ObjectEventTemplate objectEventTemplates[64];
-    /*0x1270*/ u8 flags[300];
-    /*0x139C*/ u16 vars[256];
-    /*0x159C*/ u32 gameStats[64];
-    /*0x169C*/ struct BerryTree berryTrees[128];
-    /*0x1A9C*/ struct SecretBase secretBases[10];
-    /*0x271C*/ u8 playerRoomDecorations[12];
-    /*0x2728*/ u8 playerRoomDecorationPositions[12];
-    /*0x2734*/ u8 decorationDesks[10];
-    /*0x273E*/ u8 decorationChairs[10];
-    /*0x2748*/ u8 decorationPlants[10];
-    /*0x2752*/ u8 decorationOrnaments[30];
-    /*0x2770*/ u8 decorationMats[30];
-    /*0x278E*/ u8 decorationPosters[10];
-    /*0x2798*/ u8 decorationDolls[40];
-    /*0x27C0*/ u8 decorationCushions[10];
-    /*0x27CC*/ TVShow tvShows[10];
-    /*0x2B50*/ PokeNews pokeNews[16];
-    /*0x2B90*/ u16 outbreakPokemonSpecies;
-    /*0x2B92*/ u8 outbreakLocationMapNum;
-    /*0x2B93*/ u8 outbreakLocationMapGroup;
-    /*0x2B94*/ u8 outbreakPokemonLevel;
-    /*0x2B95*/ u8 outbreakUnused1;
-    /*0x2B96*/ u16 outbreakUnused2;
-    /*0x2B98*/ u16 outbreakPokemonMoves[4];
-    /*0x2BA0*/ u8 outbreakUnused3;
-    /*0x2BA1*/ u8 outbreakPokemonProbability;
-    /*0x2BA2*/ u16 outbreakDaysLeft;
-    /*0x2BA4*/ struct GabbyAndTyData gabbyAndTyData;
-    /*0x2BB0*/ u16 easyChatProfile[6];
-    /*0x2BBC*/ u16 easyChatBattleStart[6];
-    /*0x2BC8*/ u16 easyChatBattleWon[6];
-    /*0x2BD4*/ u16 easyChatBattleLost[6];
-    /*0x2BE0*/ struct Mail mail[11];
-    /*0x2E20*/ u8 additionalPhrases[5]; // bitfield for 33 additional phrases in easy chat system
-    /*0x2E25*/ //u8 padding5[3];
-    /*0x2E28*/ OldMan oldMan;
-    /*0x2e64*/ struct DewfordTrend dewfordTrends[5];
-    /*0x2e90*/ struct ContestWinner contestWinners[13]; // see CONTEST_WINNER_*
-    /*0x3030*/ struct DayCare daycare;
-    /*0x3150*/ struct LinkBattleRecords linkBattleRecords;
-    /*0x31A8*/ u8 giftRibbons[11];
-    /*0x31B3*/ struct ExternalEventData externalEventData;
-    /*0x31C7*/ struct ExternalEventFlags externalEventFlags;
-    /*0x31DC*/ struct Roamer roamer;
-    /*0x31F8*/ struct EnigmaBerry enigmaBerry;
-    /*0x322C*/ struct MysteryGiftSave mysteryGift;
-    /*0x3598*/ u8 unused_3598[0x180];
-    /*0x3718*/ u32 trainerHillTimes[4];
-    /*0x3728*/ struct RamScript ramScript;
-    /*0x3B14*/ struct RecordMixingGift recordMixingGift;
-    /*0x3B24*/ u8 seen2[52];
-    /*0x3B58*/ LilycoveLady lilycoveLady;
-    /*0x3B98*/ struct TrainerNameRecord trainerNameRecords[20];
-    /*0x3C88*/ u8 registeredTexts[10][21];
-    /*0x3D5A*/ u8 unused_3D5A[10];
-    /*0x3D64*/ struct TrainerHillSave trainerHill;
-    /*0x3D70*/ struct WaldaPhrase waldaPhrase;
-    /*0x3D88*/ u8 NuzlockeEncounterFlags[9]; //tx_randomizer_and_challenges
+    struct Coords16 pos;
+    struct WarpData location;
+    struct WarpData continueGameWarp;
+    struct WarpData dynamicWarp;
+    struct WarpData lastHealLocation; // used by white-out and teleport
+    struct WarpData escapeWarp; // used by Dig and Escape Rope
+    u16 savedMusic;
+    u8 weather;
+    u8 weatherCycleStage;
+    u8 flashLevel;
+    //u8 padding1;
+    u16 mapLayoutId;
+    u16 mapView[0x100];
+    u8 playerPartyCount;
+    //u8 padding2[3];
+    struct Pokemon playerParty[6];
+    u32 money;
+    u16 coins;
+    u16 registeredItem; // registered for use with SELECT button
+    struct ItemSlot pcItems[50];
+    struct ItemSlot bagPocket_Items[30];
+    struct ItemSlot bagPocket_KeyItems[30];
+    struct ItemSlot bagPocket_PokeBalls[16];
+    struct ItemSlot bagPocket_TMHM[64];
+    struct ItemSlot bagPocket_Berries[46];
+    struct Pokeblock pokeblocks[40];
+    u8 seen1[52];   //52 bytes
+    u16 berryBlenderRecords[3];
+    u8 unused_9C2[6];
+    u16 trainerRematchStepCounter;    //104 bytes
+    u8 trainerRematches[100];
+    //u8 padding3[2];
+    struct ObjectEvent_v0 objectEvents[16];
+    struct ObjectEventTemplate objectEventTemplates[64];
+    u8 flags[300];
+    u16 vars[256];
+    u32 gameStats[64];
+    struct BerryTree berryTrees[128];
+    struct SecretBase secretBases[10];
+    u8 playerRoomDecorations[12];
+    u8 playerRoomDecorationPositions[12];
+    u8 decorationDesks[10];
+    u8 decorationChairs[10];
+    u8 decorationPlants[10];
+    u8 decorationOrnaments[30];
+    u8 decorationMats[30];
+    u8 decorationPosters[10];
+    u8 decorationDolls[40];
+    u8 decorationCushions[10];
+    TVShow tvShows[10];
+    PokeNews pokeNews[16];
+    u16 outbreakPokemonSpecies;
+    u8 outbreakLocationMapNum;
+    u8 outbreakLocationMapGroup;
+    u8 outbreakPokemonLevel;
+    u8 outbreakUnused1;
+    u16 outbreakUnused2;
+    u16 outbreakPokemonMoves[4];
+    u8 outbreakUnused3;
+    u8 outbreakPokemonProbability;
+    u16 outbreakDaysLeft;
+    struct GabbyAndTyData gabbyAndTyData;
+    u16 easyChatProfile[6];
+    u16 easyChatBattleStart[6];
+    u16 easyChatBattleWon[6];
+    u16 easyChatBattleLost[6];
+    struct Mail mail[11];
+    u8 additionalPhrases[5]; // bitfield for 33 additional phrases in easy chat system
+    //u8 padding5[3];
+    OldMan oldMan;
+    struct DewfordTrend dewfordTrends[5];
+    struct ContestWinner contestWinners[13]; // see CONTEST_WINNER_*
+    struct DayCare daycare;
+    struct LinkBattleRecords linkBattleRecords;
+    u8 giftRibbons[11];
+    struct ExternalEventData externalEventData;
+    struct ExternalEventFlags externalEventFlags;
+    struct Roamer roamer;
+    struct EnigmaBerry enigmaBerry;
+    struct MysteryGiftSave mysteryGift;
+    u8 unused_3598[0x180];
+    u32 trainerHillTimes[4];
+    struct RamScript ramScript;
+    struct RecordMixingGift recordMixingGift;
+    u8 seen2[52];
+    LilycoveLady lilycoveLady;
+    struct TrainerNameRecord trainerNameRecords[20];
+    u8 registeredTexts[10][21];
+    u8 unused_3D5A[10];
+    struct TrainerHillSave trainerHill;
+    struct WaldaPhrase waldaPhrase;
+    // Additional fields beyond retail
+    u8 NuzlockeEncounterFlags[9]; //tx_randomizer_and_challenges
     u8 tx_Random_Chaos: 1;
     u8 tx_Random_WildPokemon: 1;
     u8 tx_Random_Similar: 1;
@@ -241,65 +245,7 @@ struct SaveBlock1_v0 {
     u8 tx_Random_Starter: 1;
     u8 dexNavSearchLevels[412];
     u8 dexNavChain;
-    // sizeof: 0x3D88
 };
-
-bool8 UpdateObjectEvent_v0_v1(const struct ObjectEvent_v0 *in, struct ObjectEvent *out) {
-#define COPY_FIELD(field) out->field = in->field;
-    COPY_FIELD(active);
-    COPY_FIELD(singleMovementActive);
-    COPY_FIELD(triggerGroundEffectsOnMove);
-    COPY_FIELD(triggerGroundEffectsOnStop);
-    COPY_FIELD(disableCoveringGroundEffects);
-    COPY_FIELD(landingJump);
-    COPY_FIELD(heldMovementActive);
-    COPY_FIELD(heldMovementFinished);
-    COPY_FIELD(frozen);
-    COPY_FIELD(facingDirectionLocked);
-    COPY_FIELD(disableAnim);
-    COPY_FIELD(enableAnim);
-    COPY_FIELD(inanimate);
-    COPY_FIELD(invisible);
-    COPY_FIELD(offScreen);
-    COPY_FIELD(trackedByCamera);
-    COPY_FIELD(isPlayer);
-    COPY_FIELD(hasReflection);
-    COPY_FIELD(inShortGrass);
-    COPY_FIELD(inShallowFlowingWater);
-    COPY_FIELD(inSandPile);
-    COPY_FIELD(inHotSprings);
-    COPY_FIELD(noShadow);
-    COPY_FIELD(spriteAnimPausedBackup);
-    COPY_FIELD(spriteAffineAnimPausedBackup);
-    COPY_FIELD(disableJumpLandingGroundEffect);
-    COPY_FIELD(fixedPriority);
-    COPY_FIELD(hideReflection);
-    COPY_FIELD(graphicsId);
-    COPY_FIELD(movementType);
-    COPY_FIELD(trainerType);
-    COPY_FIELD(localId);
-    COPY_FIELD(mapNum);
-    COPY_FIELD(mapGroup);
-    COPY_FIELD(currentElevation);
-    COPY_FIELD(previousElevation);
-    out->initialCoords = in->initialCoords;
-    out->currentCoords = in->currentCoords;
-    out->previousCoords = in->previousCoords;
-    COPY_FIELD(facingDirection);
-    COPY_FIELD(movementDirection);
-    COPY_FIELD(rangeX);
-    COPY_FIELD(rangeY);
-    COPY_FIELD(fieldEffectSpriteId);
-    COPY_FIELD(warpArrowSpriteId);
-    COPY_FIELD(movementActionId);
-    COPY_FIELD(trainerRange_berryTreeId);
-    COPY_FIELD(currentMetatileBehavior);
-    COPY_FIELD(previousMetatileBehavior);
-    COPY_FIELD(previousMovementDirection);
-    COPY_FIELD(directionSequenceIndex);
-    CpuCopy16(&in->extra, &out->extra, sizeof(in->extra));
-#undef COPY_FIELD
-}
 
 /**
  * The following is the function which copies all the data from the old save file to the new one.
@@ -377,12 +323,6 @@ bool8 UpdateSave_v0_v1(const struct SaveSectorLocation *locations) {
     COPY_FIELD(savedMusic);
     COPY_FIELD(mapLayoutId);
     COPY_BLOCK(mapView);
-    /** Convert over all the object events from the old format for the Ghoul expansion */
-    for (i = 0; i < ARRAY_COUNT(&sOldSaveBlock1Ptr->objectEvents); i++)
-    {
-        UpdateObjectEvent_v0_v1(&sOldSaveBlock1Ptr->objectEvents[i], &gSaveBlock1Ptr->objectEvents[i]);
-    }
-    /** For some reason we also need to copy the block or else sprites won't show up */
     COPY_BLOCK(objectEvents);
     COPY_BLOCK(objectEventTemplates);
 
@@ -533,7 +473,7 @@ bool8 UpdateSave_v0_v1(const struct SaveSectorLocation *locations) {
     SetContinueGameWarpStatus();
     gSaveBlock1Ptr->continueGameWarp = gSaveBlock1Ptr->lastHealLocation;
 
-    return 1;
+    return TRUE;
 }
 
 

--- a/src/data/old_saves/save.v1.h
+++ b/src/data/old_saves/save.v1.h
@@ -1,15 +1,79 @@
+/**
+ * @author Isaac Aronson (Discord: @luigi___) (github.com/aronson)
+ * @details Records the v1 save file format structures.
+ * original code by tustin2121
+ */
 #ifndef MOEMON_EMERALD_SAVE_V1_H
 #define MOEMON_EMERALD_SAVE_V1_H
 
-#include "constants/vars.h"
-#include "constants/flags.h"
+#include "global.h"
+#include "save.h"
 
-#define NUM_DEX_FLAG_BYTES ROUND_BITS_TO_BYTES(NUM_SPECIES)
-#define NUM_FLAG_BYTES ROUND_BITS_TO_BYTES(FLAGS_COUNT)
-#define NUM_ADDITIONAL_PHRASE_BYTES ROUND_BITS_TO_BYTES(NUM_ADDITIONAL_PHRASES)
+struct ObjectEvent_v1 {
+    u32 active: 1;
+    u32 singleMovementActive: 1;
+    u32 triggerGroundEffectsOnMove: 1;
+    u32 triggerGroundEffectsOnStop: 1;
+    u32 disableCoveringGroundEffects: 1;
+    u32 landingJump: 1;
+    u32 heldMovementActive: 1;
+    u32 heldMovementFinished: 1;
+    u32 frozen: 1;
+    u32 facingDirectionLocked: 1;
+    u32 disableAnim: 1;
+    u32 enableAnim: 1;
+    u32 inanimate: 1;
+    u32 invisible: 1;
+    u32 offScreen: 1;
+    u32 trackedByCamera: 1;
+    u32 isPlayer: 1;
+    u32 hasReflection: 1;
+    u32 inShortGrass: 1;
+    u32 inShallowFlowingWater: 1;
+    u32 inSandPile: 1;
+    u32 inHotSprings: 1;
+    u32 noShadow: 1;
+    u32 spriteAnimPausedBackup: 1;
+    u32 spriteAffineAnimPausedBackup: 1;
+    u32 disableJumpLandingGroundEffect: 1;
+    u32 fixedPriority: 1;
+    u32 hideReflection: 1;
+    u16 graphicsId;
+    u8 movementType;
+    u8 trainerType;
+    u8 localId;
+    u8 mapNum;
+    u8 mapGroup;
+    u8 currentElevation: 4;
+    u8 previousElevation: 4;
+    struct Coords16 initialCoords;
+    struct Coords16 currentCoords;
+    struct Coords16 previousCoords;
+    u16 facingDirection: 4; // current direction?
+    u16 movementDirection: 4;
+    u16 rangeX: 4;
+    u16 rangeY: 4;
+    u8 fieldEffectSpriteId;
+    u8 warpArrowSpriteId;
+    u8 movementActionId;
+    u8 trainerRange_berryTreeId;
+    u8 currentMetatileBehavior;
+    u8 previousMetatileBehavior;
+    u8 previousMovementDirection;
+    u8 directionSequenceIndex;
+    union __attribute__((packed)) {
+        u8 playerCopyableMovement; // COPY_MOVE_*
+        struct __attribute__((packed)) {
+            u16 species: 10; // 11 bits; 1024 species
+            u16 form: 5; // Used for Deoxys, Unown, etc
+            u16 shiny: 1;
+        } mon;
+        u16 asU16;
+    } extra;
+    u8 spriteId;
+};
 
-struct SaveBlock2_v1
-{
+struct SaveBlock2_v1 {
     u8 _saveSentinel; // 0xFF
     // u8 unused;
     u16 saveVersion;
@@ -22,12 +86,12 @@ struct SaveBlock2_v1
     u8 playTimeSeconds;
     u8 playTimeVBlanks;
     u8 optionsButtonMode;  // OPTIONS_BUTTON_MODE_[NORMAL/LR/L_EQUALS_A]
-    u16 optionsTextSpeed:3; // OPTIONS_TEXT_SPEED_[SLOW/MID/FAST]
-    u16 optionsWindowFrameType:5; // Specifies one of the 20 decorative borders for text boxes
-    u16 optionsSound:1; // OPTIONS_SOUND_[MONO/STEREO]
-    u16 optionsBattleStyle:1; // OPTIONS_BATTLE_STYLE_[SHIFT/SET]
-    u16 optionsBattleSceneOff:1; // whether battle animations are disabled
-    u16 regionMapZoom:1; // whether the map is zoomed in
+    u16 optionsTextSpeed: 3; // OPTIONS_TEXT_SPEED_[SLOW/MID/FAST]
+    u16 optionsWindowFrameType: 5; // Specifies one of the 20 decorative borders for text boxes
+    u16 optionsSound: 1; // OPTIONS_SOUND_[MONO/STEREO]
+    u16 optionsBattleStyle: 1; // OPTIONS_BATTLE_STYLE_[SHIFT/SET]
+    u16 optionsBattleSceneOff: 1; // whether battle animations are disabled
+    u16 regionMapZoom: 1; // whether the map is zoomed in
     //u16 padding1:4;
     //u16 padding2;
     struct Pokedex pokedex;
@@ -48,143 +112,141 @@ struct SaveBlock2_v1
     u8 itemFlags[50];
 };
 
-struct SaveBlock1_v1
-{
-    /*0x00*/ struct Coords16 pos;
-    /*0x04*/ struct WarpData location;
-    /*0x0C*/ struct WarpData continueGameWarp;
-    /*0x14*/ struct WarpData dynamicWarp;
-    /*0x1C*/ struct WarpData lastHealLocation; // used by white-out and teleport
-    /*0x24*/ struct WarpData escapeWarp; // used by Dig and Escape Rope
-    /*0x2C*/ u16 savedMusic;
-    /*0x2E*/ u8 weather;
-    /*0x2F*/ u8 weatherCycleStage;
-    /*0x30*/ u8 flashLevel;
-    /*0x31*/ //u8 padding1;
-    /*0x32*/ u16 mapLayoutId;
-    /*0x34*/ u16 mapView[0x100];
-    /*0x234*/ u8 playerPartyCount;
-    /*0x235*/ //u8 padding2[3];
-    /*0x238*/ struct Pokemon playerParty[6];
-    /*0x490*/ u32 money;
-    /*0x494*/ u16 coins;
-    /*0x496*/ u16 registeredItem; // registered for use with SELECT button
-    /*0x498*/ struct ItemSlot pcItems[50];
-    /*0x560*/ struct ItemSlot bagPocket_Items[30];
-    /*0x5D8*/ struct ItemSlot bagPocket_KeyItems[30];
-    /*0x650*/ struct ItemSlot bagPocket_PokeBalls[16];
-    /*0x690*/ struct ItemSlot bagPocket_TMHM[64];
-    /*0x790*/ struct ItemSlot bagPocket_Berries[46];
-    /*0x848*/ struct Pokeblock pokeblocks[40];
-    /*0x988*/ u8 seen1[52];   //52 bytes
-    /*0x9BC*/ u16 berryBlenderRecords[3];
-    /*0x9C2*/ u8 unused_9C2[6];
-    /*0x9C8*/ u16 trainerRematchStepCounter;    //104 bytes
-    /*0x9CA*/ u8 trainerRematches[100];
-    /*0xA2E*/ //u8 padding3[2];
-    /*0xA30*/ struct ObjectEvent objectEvents[16];
-    /*0xC70*/ struct ObjectEventTemplate objectEventTemplates[64];
-    /*0x1270*/ u8 flags[NUM_FLAG_BYTES];
-    /*0x139C*/ u16 vars[VARS_COUNT];
-    /*0x159C*/ u32 gameStats[64];
-    /*0x169C*/ struct BerryTree berryTrees[128];
-    /*0x1A9C*/ struct SecretBase secretBases[10];
-    /*0x271C*/ u8 playerRoomDecorations[12];
-    /*0x2728*/ u8 playerRoomDecorationPositions[12];
-    /*0x2734*/ u8 decorationDesks[10];
-    /*0x273E*/ u8 decorationChairs[10];
-    /*0x2748*/ u8 decorationPlants[10];
-    /*0x2752*/ u8 decorationOrnaments[30];
-    /*0x2770*/ u8 decorationMats[30];
-    /*0x278E*/ u8 decorationPosters[10];
-    /*0x2798*/ u8 decorationDolls[40];
-    /*0x27C0*/ u8 decorationCushions[10];
-    /*0x27CC*/ TVShow tvShows[10];
-    /*0x2B50*/ PokeNews pokeNews[16];
-    /*0x2B90*/ u16 outbreakPokemonSpecies;
-    /*0x2B92*/ u8 outbreakLocationMapNum;
-    /*0x2B93*/ u8 outbreakLocationMapGroup;
-    /*0x2B94*/ u8 outbreakPokemonLevel;
-    /*0x2B95*/ u8 outbreakUnused1;
-    /*0x2B96*/ u16 outbreakUnused2;
-    /*0x2B98*/ u16 outbreakPokemonMoves[4];
-    /*0x2BA0*/ u8 outbreakUnused3;
-    /*0x2BA1*/ u8 outbreakPokemonProbability;
-    /*0x2BA2*/ u16 outbreakDaysLeft;
-    /*0x2BA4*/ struct GabbyAndTyData gabbyAndTyData;
-    /*0x2BB0*/ u16 easyChatProfile[6];
-    /*0x2BBC*/ u16 easyChatBattleStart[6];
-    /*0x2BC8*/ u16 easyChatBattleWon[6];
-    /*0x2BD4*/ u16 easyChatBattleLost[6];
-    /*0x2BE0*/ struct Mail mail[11];
-    /*0x2E20*/ u8 additionalPhrases[NUM_ADDITIONAL_PHRASE_BYTES]; // bitfield for 33 additional phrases in easy chat system
-    /*0x2E25*/ //u8 padding5[3];
-    /*0x2E28*/ OldMan oldMan;
-    /*0x2e64*/ struct DewfordTrend dewfordTrends[5];
-    /*0x2e90*/ struct ContestWinner contestWinners[13]; // see CONTEST_WINNER_*
-    /*0x3030*/ struct DayCare daycare;
-    /*0x3150*/ struct LinkBattleRecords linkBattleRecords;
-    /*0x31A8*/ u8 giftRibbons[11];
-    /*0x31B3*/ struct ExternalEventData externalEventData;
-    /*0x31C7*/ struct ExternalEventFlags externalEventFlags;
-    /*0x31DC*/ struct Roamer roamer;
-    /*0x31F8*/ struct EnigmaBerry enigmaBerry;
-    /*0x322C*/ struct MysteryGiftSave mysteryGift;
-    /*0x3598*/ u8 unused_3598[0x180];
-    /*0x3718*/ u32 trainerHillTimes[4];
-    /*0x3728*/ struct RamScript ramScript;
-    /*0x3B14*/ struct RecordMixingGift recordMixingGift;
-    /*0x3B24*/ u8 seen2[NUM_DEX_FLAG_BYTES];
-    /*0x3B58*/ LilycoveLady lilycoveLady;
-    /*0x3B98*/ struct TrainerNameRecord trainerNameRecords[20];
-    /*0x3C88*/ u8 registeredTexts[10][21];
-    /*0x3D5A*/ u8 unused_3D5A[10];
-    /*0x3D64*/ struct TrainerHillSave trainerHill;
-    /*0x3D70*/ struct WaldaPhrase waldaPhrase;
-    /*0x3D88*/ u8 NuzlockeEncounterFlags[9]; //tx_randomizer_and_challenges
-    u8 tx_Random_Chaos:1;
-    u8 tx_Random_WildPokemon:1;
-    u8 tx_Random_Similar:1;
-    u8 tx_Random_MapBased:1;
-    u8 tx_Random_IncludeLegendaries:1;
-    u8 tx_Random_Type:1;
-    u8 tx_Random_TypeEffectiveness:1;
-    u8 tx_Random_Abilities:1;
+struct SaveBlock1_v1 {
+    struct Coords16 pos
+    struct WarpData location;
+    struct WarpData continueGameWarp;
+    struct WarpData dynamicWarp;
+    struct WarpData lastHealLocation; // used by white-out and teleport
+    struct WarpData escapeWarp; // used by Dig and Escape Rope
+    u16 savedMusic;
+    u8 weather;
+    u8 weatherCycleStage;
+    u8 flashLevel;
+    //u8 padding1;
+    u16 mapLayoutId;
+    u16 mapView[0x100];
+    u8 playerPartyCount;
+    //u8 padding2[3];
+    struct Pokemon playerParty[6];
+    u32 money;
+    u16 coins;
+    u16 registeredItem; // registered for use with SELECT button
+    struct ItemSlot pcItems[50];
+    struct ItemSlot bagPocket_Items[30];
+    struct ItemSlot bagPocket_KeyItems[30];
+    struct ItemSlot bagPocket_PokeBalls[16];
+    struct ItemSlot bagPocket_TMHM[64];
+    struct ItemSlot bagPocket_Berries[46];
+    struct Pokeblock pokeblocks[40];
+    u8 seen1[52];   //52 bytes
+    u16 berryBlenderRecords[3];
+    u8 unused_9C2[6];
+    u16 trainerRematchStepCounter;    //104 bytes
+    u8 trainerRematches[100];
+    //u8 padding3[2];
+    struct ObjectEvent_v1 objectEvents[16];
+    struct ObjectEventTemplate objectEventTemplates[64];
+    u8 flags[300];
+    u16 vars[256];
+    u32 gameStats[64];
+    struct BerryTree berryTrees[128];
+    struct SecretBase secretBases[10];
+    u8 playerRoomDecorations[12];
+    u8 playerRoomDecorationPositions[12];
+    u8 decorationDesks[10];
+    u8 decorationChairs[10];
+    u8 decorationPlants[10];
+    u8 decorationOrnaments[30];
+    u8 decorationMats[30];
+    u8 decorationPosters[10];
+    u8 decorationDolls[40];
+    u8 decorationCushions[10];
+    TVShow tvShows[10];
+    PokeNews pokeNews[16];
+    u16 outbreakPokemonSpecies;
+    u8 outbreakLocationMapNum;
+    u8 outbreakLocationMapGroup;
+    u8 outbreakPokemonLevel;
+    u8 outbreakUnused1;
+    u16 outbreakUnused2;
+    u16 outbreakPokemonMoves[4];
+    u8 outbreakUnused3;
+    u8 outbreakPokemonProbability;
+    u16 outbreakDaysLeft;
+    struct GabbyAndTyData gabbyAndTyData;
+    u16 easyChatProfile[6];
+    u16 easyChatBattleStart[6];
+    u16 easyChatBattleWon[6];
+    u16 easyChatBattleLost[6];
+    struct Mail mail[11];
+    u8 additionalPhrases[5]; // bitfield for 33 additional phrases in easy chat system
+    //u8 padding5[3];
+    OldMan oldMan;
+    struct DewfordTrend dewfordTrends[5];
+    struct ContestWinner contestWinners[13]; // see CONTEST_WINNER_*
+    struct DayCare daycare;
+    struct LinkBattleRecords linkBattleRecords;
+    u8 giftRibbons[11];
+    struct ExternalEventData externalEventData;
+    struct ExternalEventFlags externalEventFlags;
+    struct Roamer roamer;
+    struct EnigmaBerry enigmaBerry;
+    struct MysteryGiftSave mysteryGift;
+    u8 unused_3598[0x180];
+    u32 trainerHillTimes[4];
+    struct RamScript ramScript;
+    struct RecordMixingGift recordMixingGift;
+    u8 seen2[52];
+    LilycoveLady lilycoveLady;
+    struct TrainerNameRecord trainerNameRecords[20];
+    u8 registeredTexts[10][21];
+    u8 unused_3D5A[10];
+    struct TrainerHillSave trainerHill;
+    struct WaldaPhrase waldaPhrase;
+    // Additional fields beyond retail
+    u8 NuzlockeEncounterFlags[9]; //tx_randomizer_and_challenges
+    u8 tx_Random_Chaos: 1;
+    u8 tx_Random_WildPokemon: 1;
+    u8 tx_Random_Similar: 1;
+    u8 tx_Random_MapBased: 1;
+    u8 tx_Random_IncludeLegendaries: 1;
+    u8 tx_Random_Type: 1;
+    u8 tx_Random_TypeEffectiveness: 1;
+    u8 tx_Random_Abilities: 1;
     //
-    u8 tx_Random_Moves:1;
-    u8 tx_Random_Trainer:1;
-    u8 tx_Random_Evolutions:1;
-    u8 tx_Random_EvolutionMethods:1;
-    u8 tx_Challenges_EvoLimit:2;
-    u8 tx_Challenges_Nuzlocke:1;
-    u8 tx_Challenges_NuzlockeHardcore:1;
+    u8 tx_Random_Moves: 1;
+    u8 tx_Random_Trainer: 1;
+    u8 tx_Random_Evolutions: 1;
+    u8 tx_Random_EvolutionMethods: 1;
+    u8 tx_Challenges_EvoLimit: 2;
+    u8 tx_Challenges_Nuzlocke: 1;
+    u8 tx_Challenges_NuzlockeHardcore: 1;
     //
-    u8 tx_Challenges_OneTypeChallenge:5;
-    u8 tx_Challenges_PartyLimit:3;
+    u8 tx_Challenges_OneTypeChallenge: 5;
+    u8 tx_Challenges_PartyLimit: 3;
     //
-    u8 tx_Challenges_NoItemPlayer:1;
-    u8 tx_Challenges_NoItemTrainer:1;
-    u8 tx_Challenges_PkmnCenter:2;
-    u8 tx_Random_OneForOne:1; //unused
-    u8 tx_Challenges_BaseStatEqualizer:2;
-    u8 tx_Challenges_LevelCap:2;
-    u8 tx_Challenges_ExpMultiplier:2;
-    u8 tx_Random_Items:1;
-    u8 tx_Nuzlocke_SpeciesClause:1;
-    u8 tx_Nuzlocke_ShinyClause:1;
-    u8 tx_Nuzlocke_Nicknaming:1;
-    u8 tx_Challenges_Mirror:1;
-    u8 tx_Challenges_Mirror_Thief:1;
-    u8 tx_Random_Static:1;
-    u8 tx_Challenges_NoEVs:1;
-    u8 tx_Challenges_TrainerScalingIVs:2;
-    u8 tx_Challenges_TrainerScalingEVs:2;
-    u8 tx_Nuzlocke_Deletion:1;
-    u8 tx_Random_Starter:1;
+    u8 tx_Challenges_NoItemPlayer: 1;
+    u8 tx_Challenges_NoItemTrainer: 1;
+    u8 tx_Challenges_PkmnCenter: 2;
+    u8 tx_Random_OneForOne: 1; //unused
+    u8 tx_Challenges_BaseStatEqualizer: 2;
+    u8 tx_Challenges_LevelCap: 2;
+    u8 tx_Challenges_ExpMultiplier: 2;
+    u8 tx_Random_Items: 1;
+    u8 tx_Nuzlocke_SpeciesClause: 1;
+    u8 tx_Nuzlocke_ShinyClause: 1;
+    u8 tx_Nuzlocke_Nicknaming: 1;
+    u8 tx_Challenges_Mirror: 1;
+    u8 tx_Challenges_Mirror_Thief: 1;
+    u8 tx_Random_Static: 1;
+    u8 tx_Challenges_NoEVs: 1;
+    u8 tx_Challenges_TrainerScalingIVs: 2;
+    u8 tx_Challenges_TrainerScalingEVs: 2;
+    u8 tx_Nuzlocke_Deletion: 1;
+    u8 tx_Random_Starter: 1;
     u8 dexNavSearchLevels[412];
     u8 dexNavChain;
-    // sizeof: 0x3D88
 };
-
 
 #endif //MOEMON_EMERALD_SAVE_V1_H

--- a/src/save.c
+++ b/src/save.c
@@ -1,10 +1,12 @@
 #include "global.h"
-#include "malloc.h"
 #include "agb_flash.h"
 #include "gba/flash_internal.h"
 #include "fieldmap.h"
 #include "save.h"
 #include "task.h"
+#include "malloc.h"
+#include "strings.h"
+#include "string_util.h"
 #include "decompress.h"
 #include "load_save.h"
 #include "overworld.h"
@@ -506,7 +508,7 @@ static u8 CopySaveSlotData(u16 sectorId, struct SaveSectorLocation *locations)
         if (id == 0)
             gLastWrittenSector = i;
 
-        checksum = CalculateChecksum(gReadWriteSector->data, locations[id].size);
+        checksum = CalculateChecksum(gReadWriteSector->data, SECTOR_DATA_SIZE);
 
         // Only copy data for sectors whose signature and checksum fields are correct
         if (gReadWriteSector->signature == SECTOR_SIGNATURE && gReadWriteSector->checksum == checksum)
@@ -538,7 +540,7 @@ static u8 GetSaveValidStatus(const struct SaveSectorLocation *locations)
         if (gReadWriteSector->signature == SECTOR_SIGNATURE)
         {
             signatureValid = TRUE;
-            checksum = CalculateChecksum(gReadWriteSector->data, locations[gReadWriteSector->id].size);
+            checksum = CalculateChecksum(gReadWriteSector->data, SECTOR_DATA_SIZE);
             if (gReadWriteSector->checksum == checksum)
             {
                 saveSlot1Counter = gReadWriteSector->counter;
@@ -570,7 +572,7 @@ static u8 GetSaveValidStatus(const struct SaveSectorLocation *locations)
         if (gReadWriteSector->signature == SECTOR_SIGNATURE)
         {
             signatureValid = TRUE;
-            checksum = CalculateChecksum(gReadWriteSector->data, locations[gReadWriteSector->id].size);
+            checksum = CalculateChecksum(gReadWriteSector->data, SECTOR_DATA_SIZE);
             if (gReadWriteSector->checksum == checksum)
             {
                 saveSlot2Counter = gReadWriteSector->counter;
@@ -652,7 +654,7 @@ static u8 TryLoadSaveSector(u8 sectorId, u8 *data, u16 size)
     ReadFlashSector(sectorId, sector);
     if (sector->signature == SECTOR_SIGNATURE)
     {
-        u16 checksum = CalculateChecksum(sector->data, size);
+        u16 checksum = CalculateChecksum(sector->data, SECTOR_DATA_SIZE);
         if (sector->id == checksum)
         {
             // Signature and checksum are correct, copy data
@@ -1074,7 +1076,7 @@ bool8 UpdateSaveFile(void)
     u8* ptr1;
     u8* ptr2;
     u8* ptr3;
-    int i, x;
+    int i;
     bool8 result = TRUE;
     // Load the old save file into the heap
     sOldSaveBlock = AllocZeroed(SECTOR_DATA_SIZE * NUM_SECTORS_PER_SLOT);
@@ -1118,6 +1120,6 @@ bool8 UpdateSaveFile(void)
     // Clean up and perform post-load copying operations
     Free(sOldSaveBlock);
     CopyPartyAndObjectsFromSave();
-    // Note, the save is now up to date, but it won't be saved back to FLASH until the player saves the game.
+    // Note, the save is now up-to-date, but it won't be saved back to FLASH until the player saves the game.
     return result;
 }

--- a/src/strings.c
+++ b/src/strings.c
@@ -1859,5 +1859,5 @@ const u8 gText_BattleRules_NoItems_Player[]                 = _("Competitive rul
 #include "data/text/teachy_tv.h"
 
 //Save strings
-const u8 gText_SaveFileOldUpdated[] = _("Your save file is for an older release\nof Moemon Emerald Vanilla+.\pYour save will be updated. Please back\nup your old save if you wish to keep it.");
-const u8 gText_SaveFileOldErrored[] = _("Your save file is for an older release\nof Moemon Emerald Vanilla+.\pThe attempt to update the save file\nhas failed.\pPlease report this to the author.");
+const u8 gText_SaveFileOldUpdated[] = _("Your save file is for an older release\nof Moemon Vanilla+ Emerald.\pYour save will be updated. Please back\nup your old save if you wish to keep it.");
+const u8 gText_SaveFileOldErrored[] = _("Your save file is for an older release\nof Moemon Vanilla+ Emerald.\pThe attempt to update the save file\nhas failed.\pPlease report this to the author.");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The save upgrade code I put out worked, but does some unnecessary operations. Now that there's no pressure to support upgrades quickly I've simplified it, reformatted it, and cleaned it up. Tested and working just the same as before.

I also made a (now correct) copy of the current save as a v1 header so that you won't have to re-create it if and when you change the saveblock.

## **Discord contact info**
`luigi___`
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
