### PR TITLE
Reduce filesize of modern build by 444KB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ $(C_BUILDDIR)/record_mixing.o: CFLAGS += -ffreestanding
 $(C_BUILDDIR)/librfu_intr.o: CC1 := tools/agbcc/bin/agbcc_arm$(EXE)
 $(C_BUILDDIR)/librfu_intr.o: CFLAGS := -O2 -mthumb-interwork -quiet
 else
-$(C_BUILDDIR)/librfu_intr.o: CFLAGS := -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
+$(C_BUILDDIR)/librfu_intr.o: CFLAGS := -mthumb-interwork -Os -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast -flto -ffat-lto-objects
 endif
 
 ifeq ($(DINFO),1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I changed the compile flags to reduce the size of the compiled code.

Specifically:
- Changed `-O2` (maximum safe optimizations) to `-Os` (many safe optimizations targeted for smaller files than `-O2`)
- Added link-time optimization (`-flto`) and required fat LTO flag (fat LTO has no effect on filesize)
- Added rebuild-modern target
- Added `-g` to modern build flags to support debugging (has no effect on filesize)

Compared to the original behavior, `-Os` and friends save 444KB on the modern compiler and almost half a MB compared to `agbcc`'s output binary. I'm still playtesting, but I don't anticipate any functional changes to the gameplay (e.g. lag).

I know size constraints are a consideration in your codebase, so here you go!

P.S.: I tried a few other compile flags known to reduce space, but they either broke the build or did nothing.

## **Discord contact info**
`luigi___`
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
