### PR TITLE
Enable Reset RTC feature

### DIFF
--- a/src/title_screen.c
+++ b/src/title_screen.c
@@ -730,8 +730,7 @@ static void Task_TitleScreenPhase3(u8 taskId)
     {
         SetMainCallback2(CB2_GoToClearSaveDataScreen);
     }
-    else if (JOY_HELD(RESET_RTC_BUTTON_COMBO) == RESET_RTC_BUTTON_COMBO
-      && CanResetRTC() == TRUE)
+    else if (JOY_HELD(RESET_RTC_BUTTON_COMBO) == RESET_RTC_BUTTON_COMBO)
     {
         FadeOutBGM(4);
         BeginNormalPaletteFade(PALETTES_ALL, 0, 0, 0x10, RGB_BLACK);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This changes one if statement to enable a built-in screen that allows the user to reset the RTC hardware on their cart.

This is incredibly useful for users on real hardware using a cart that have the wrong time and don't want the debug menu.

Holding `B + Select + Left Arrow` when loading the title screen enables the menu.

## **Discord contact info**
`luigi___`
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
