### PR TITLE
Add rumble support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,6 +425,7 @@ endif
 $(OBJ_DIR)/ld_script.ld: $(LD_SCRIPT) $(LD_SCRIPT_DEPS)
 	cd $(OBJ_DIR) && sed "s#tools/#../../tools/#g" ../../$(LD_SCRIPT) > ld_script.ld
 
+LDFLAGS = -Map ../../$(MAP) --no-warn-rwx-segments
 $(ELF): $(OBJ_DIR)/ld_script.ld $(OBJS) libagbsyscall
 	@echo "cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ld_script.ld -o ../../$@ <objects> <lib>"
 	@cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ld_script.ld -o ../../$@ $(OBJS_REL) $(LIB)

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ LIBPATH := -L ../../tools/agbcc/lib
 LIB := $(LIBPATH) -lgcc -lc -L../../libagbsyscall -lagbsyscall
 else
 CC1              = $(shell $(PATH_MODERNCC) --print-prog-name=cc1) -quiet
-override CFLAGS += -mthumb -mthumb-interwork -Os -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast -flto -ffat-lto-objects -g
+override CFLAGS += -mthumb -mthumb-interwork -Os -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast -flto -ffat-lto-objects
 ROM := $(MODERN_ROM_NAME)
 OBJ_DIR := $(MODERN_OBJ_DIR_NAME)
 LIBPATH := -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libgcc.a))" -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libnosys.a))" -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libc.a))"
@@ -117,11 +117,6 @@ endif
 CPPFLAGS := -iquote include -iquote $(GFLIB_SUBDIR) -Wno-trigraphs -DMODERN=$(MODERN)
 ifneq ($(MODERN),1)
 CPPFLAGS += -I tools/agbcc/include -I tools/agbcc -nostdinc -undef
-endif
-
-LDFLAGS = -Map ../../$(MAP)
-ifneq ($(MODERN),0)
-LDFLAGS += -flto -s --no-warn-rwx-segments
 endif
 
 
@@ -425,7 +420,11 @@ endif
 $(OBJ_DIR)/ld_script.ld: $(LD_SCRIPT) $(LD_SCRIPT_DEPS)
 	cd $(OBJ_DIR) && sed "s#tools/#../../tools/#g" ../../$(LD_SCRIPT) > ld_script.ld
 
-LDFLAGS = -Map ../../$(MAP) --no-warn-rwx-segments
+LDFLAGS = -Map ../../$(MAP)
+ifneq ($(MODERN),0)
+LDFLAGS += -flto -s
+endif
+
 $(ELF): $(OBJ_DIR)/ld_script.ld $(OBJS) libagbsyscall
 	@echo "cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ld_script.ld -o ../../$@ <objects> <lib>"
 	@cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ld_script.ld -o ../../$@ $(OBJS_REL) $(LIB)

--- a/include/crt0.h
+++ b/include/crt0.h
@@ -3,4 +3,6 @@
 
 extern u32 IntrMain[];
 
+extern void ReInitializeEWRAM();
+
 #endif //GUARD_CRT0_H

--- a/include/gba/defines.h
+++ b/include/gba/defines.h
@@ -6,8 +6,10 @@
 #define TRUE  1
 #define FALSE 0
 
-#define IWRAM_DATA __attribute__((section("iwram_data")))
-#define EWRAM_DATA __attribute__((section("ewram_data")))
+#define IWRAM_DATA __attribute__((section(".bss")))
+#define EWRAM_DATA __attribute__((section(".sbss")))
+#define IWRAM_INIT __attribute__((section(".iwram")))
+#define EWRAM_INIT __attribute__((section(".ewram")))
 #define UNUSED __attribute__((unused))
 
 #if MODERN

--- a/include/gba/io_reg.h
+++ b/include/gba/io_reg.h
@@ -774,4 +774,8 @@
 #define WAITCNT_AGB (0 << 15)
 #define WAITCNT_CGB (1 << 15)
 
+#define GPIO_PORT_DATA        (*(vu16 *)0x80000C4)
+#define GPIO_PORT_DIRECTION   (*(vu16 *)0x80000C6)
+#define GPIO_PORT_READ_ENABLE (*(vu16 *)0x80000C8)
+
 #endif // GUARD_GBA_IO_REG_H

--- a/include/rumble.h
+++ b/include/rumble.h
@@ -1,0 +1,21 @@
+#ifndef MOEMON_EMERALD_RUMBLE_H
+#define MOEMON_EMERALD_RUMBLE_H
+
+#ifndef GUARD_RUMBLE_H
+#define GUARD_RUMBLE_H
+
+enum
+{
+    RUMBLE_TYPE_OFF,
+    RUMBLE_TYPE_CONT,
+    RUMBLE_TYPE_TIMED
+};
+
+void RumbleFrameUpdate();
+bool32 SetTimedRumble(u8 deciseconds);
+bool32 RumbleStart(void);
+bool32 RumbleStop(void);
+u32 GetRumbleState(void);
+
+#endif // GUARD_RUMBLE_H
+#endif //MOEMON_EMERALD_RUMBLE_H

--- a/ld_script.txt
+++ b/ld_script.txt
@@ -3,32 +3,47 @@ ENTRY(Start)
 gNumMusicPlayers = 4;
 gMaxLines = 0;
 
-/* Modify the following load addresses as needed to make more room. Alternately, delete both the
-   declarations below and their references further down to get rid of the gaps.                  */
+MEMORY
+{
+    EWRAM (rwx) : ORIGIN = 0x2000000, LENGTH = 256K
+    IWRAM (rwx) : ORIGIN = 0x3000000, LENGTH = 32K
+    ROM    (rx) : ORIGIN = 0x8000000, LENGTH = 32M
+}
 
 SECTIONS {
-    . = 0x2000000;
 
-    ewram (NOLOAD) :
+    .ewram ORIGIN(EWRAM) : AT (__ewram_lma)
+    ALIGN(4)
+    {
+        __ewram_start = .;
+        *(.ewram*)
+        __ewram_end = .;
+    } > EWRAM
+
+    .ewram.sbss (NOLOAD) :
     ALIGN(4)
     {
         gHeap = .;
-
         . = 0x1C000;
 
         INCLUDE "sym_ewram.ld"
-        src/*.o(.ewram_data);
-        gflib/*.o(.ewram_data);
+        src/*.o(.sbss);
+        gflib/*.o(.sbss);
 
         *libc.a:impure.o(.data);
         *libc.a:locale.o(.data);
         *libc.a:mallocr.o(.data);
-        . = 0x40000;
-    }
+    } > EWRAM
 
-    . = 0x3000000;
+    .iwram ORIGIN(IWRAM) : AT (__iwram_lma)
+    ALIGN(4)
+    {
+        __iwram_start = .;
+        *(.iwram*);
+        __iwram_end = .;
+    } > IWRAM
 
-    iwram (NOLOAD) :
+    .iwram.bss (NOLOAD) :
     ALIGN(4)
     {
         /* .bss starts at 0x3000000 */
@@ -43,13 +58,11 @@ SECTIONS {
         /* COMMON starts at 0x30022A8 */
         INCLUDE "sym_common.ld"
         *libc.a:sbrkr.o(COMMON);
-        end = .;
-        . = 0x8000;
-    }
+    } > IWRAM
 
-    . = 0x8000000;
+    /* BEGIN ROM DATA */
 
-    .text :
+    .text ORIGIN(ROM) :
     ALIGN(4)
     {
         src/rom_header.o(.text);
@@ -348,7 +361,7 @@ SECTIONS {
 		src/dexnav.o(.text);
         src/teachy_tv.o(.text);
         src/mugshot.o(.text);
-    } =0
+    } >ROM =0
 
     script_data :
     ALIGN(4)
@@ -361,7 +374,7 @@ SECTIONS {
         data/battle_ai_scripts.o(script_data);
         data/contest_ai_scripts.o(script_data);
         data/mystery_event_script_cmd_table.o(script_data);
-    } =0
+    } >ROM =0
 
     lib_text :
     ALIGN(4)
@@ -445,7 +458,7 @@ SECTIONS {
         *libc.a:libcfunc.o(.text);
         *libc.a:lseekr.o(.text);
         *libc.a:readr.o(.text);
-    } =0
+    } >ROM =0
 
     .rodata :
     ALIGN(4)
@@ -719,7 +732,7 @@ SECTIONS {
 		src/dexnav.o(.rodata);
         src/teachy_tv.o(.rodata);
         src/mugshot.o(.rodata);
-    } =0
+    } >ROM =0
 
     song_data :
     ALIGN(4)
@@ -1254,7 +1267,7 @@ SECTIONS {
         sound/songs/midi/ph_nurse_blend.o(.rodata);
         sound/songs/midi/ph_nurse_held.o(.rodata);
         sound/songs/midi/ph_nurse_solo.o(.rodata);
-    } =0
+    } >ROM =0
 
     lib_rodata :
     SUBALIGN(4)
@@ -1307,7 +1320,7 @@ SECTIONS {
         *libc.a:lseekr.o(.rodata);
         *libc.a:readr.o(.rodata);
         src/libisagbprn.o(.rodata);
-    } =0
+    } >ROM =0
 
     multiboot_data :
     ALIGN(4)
@@ -1315,19 +1328,19 @@ SECTIONS {
         data/multiboot_ereader.o(.rodata);
         data/multiboot_berry_glitch_fix.o(.rodata);
         data/multiboot_pokemon_colosseum.o(.rodata);
-    } =0
+    } >ROM =0
 
     anim_mon_front_pic_data  :
     ALIGN(4)
     {
         src/anim_mon_front_pics.o(.rodata);
-    } =0
+    } >ROM =0
 
     gfx_data :
     ALIGN(4)
     {
         src/graphics.o(.rodata);
-    } =0
+    } >ROM =0
 
     extra :
     ALIGN(4)
@@ -1337,7 +1350,23 @@ SECTIONS {
         src/*.o(.rodata);
         gflib/*.o(.rodata);
         data/*.o(.rodata);
-    } = 0
+    } > ROM = 0
+
+    .data.iwram :
+    ALIGN(4)
+    {
+        __iwram_lma = .;
+        . = . + (__iwram_end - __iwram_start);
+    } > ROM = 0
+
+    .data.ewram :
+    ALIGN(4)
+    {
+        __ewram_lma = .;
+        . = . + (__ewram_end - __ewram_start);
+    } > ROM = 0
+
+    __rom_end = .;
 
     /* DWARF debug sections.
        Symbols in the DWARF debugging sections are relative to the beginning

--- a/ld_script_modern.txt
+++ b/ld_script_modern.txt
@@ -3,49 +3,61 @@ ENTRY(Start)
 gNumMusicPlayers = 4;
 gMaxLines = 0;
 
-SECTIONS {
-    . = 0x2000000;
+MEMORY
+{
+    EWRAM (rwx) : ORIGIN = 0x2000000, LENGTH = 256K
+    IWRAM (rwx) : ORIGIN = 0x3000000, LENGTH = 32K
+    ROM    (rx) : ORIGIN = 0x8000000, LENGTH = 32M
+}
 
-    ewram (NOLOAD) :
+SECTIONS {
+
+    .ewram ORIGIN(EWRAM) : AT (__ewram_lma)
+    ALIGN(4)
+    {
+        __ewram_start = .;
+        *(.ewram*)
+        __ewram_end = .;
+    } > EWRAM
+
+    .ewram.sbss (NOLOAD) :
     ALIGN(4)
     {
         gHeap = .;
-
         . = 0x1C000;
 
-        src/*.o(ewram_data);
-        gflib/*.o(ewram_data);
+        src/*.o(.sbss);
+        gflib/*.o(.sbss);
+    } > EWRAM
 
-        . = 0x40000;
-}
-
-    . = 0x3000000;
-
-    iwram (NOLOAD) :
+    .iwram ORIGIN(IWRAM) : AT (__iwram_lma)
     ALIGN(4)
     {
-        /* .bss starts at 0x3000000 */
+        __iwram_start = .;
+        *(.iwram*);
+        __iwram_end = .;
+    } > IWRAM
+
+    .iwram.bss (NOLOAD) :
+    ALIGN(4)
+    {
         src/*.o(.bss);
         gflib/*.o(.bss);
         data/*.o(.bss);
         *libc.a:*.o(.bss*);
         *libnosys.a:*.o(.bss*);
 
-        /* .bss.code starts at 0x3001AA8 */
         src/m4a.o(.bss.code);
 
-        /* COMMON starts at 0x30022A8 */
         src/*.o(COMMON);
         gflib/*.o(COMMON);
         *libc.a:*.o(COMMON);
         *libnosys.a:*.o(COMMON);
-        end = .;
-        . = 0x8000;
-    }
+    } > IWRAM
 
-    . = 0x8000000;
+    /* BEGIN ROM DATA */
 
-    .text :
+    .text ORIGIN(ROM) :
     ALIGN(4)
     {
         src/rom_header.o(.text*);
@@ -55,13 +67,13 @@ SECTIONS {
         gflib/*.o(.text*);
         src/*.o(.text*);
         asm/*.o(.text*);
-    } =0
+    } > ROM =0
 
     script_data :
     ALIGN(4)
     {
 		data/*.o(script_data);
-    } =0
+    } > ROM =0
 
     lib_text :
     ALIGN(4)
@@ -82,7 +94,7 @@ SECTIONS {
         *libc.a:*.o(.text*);
         *libnosys.a:*.o(.text*);
         src/libisagbprn.o(.text);
-    } =0
+    } > ROM =0
 
     .rodata :
     ALIGN(4)
@@ -90,13 +102,13 @@ SECTIONS {
         src/*.o(.rodata*);
         gflib/*.o(.rodata*);
         data/*.o(.rodata*);
-    } =0
+    } > ROM =0
 
     song_data :
     ALIGN(4)
     {
         sound/songs/*.o(.rodata);
-    } =0
+    } > ROM =0
 
     lib_rodata :
     SUBALIGN(4)
@@ -113,7 +125,7 @@ SECTIONS {
         *libc.a:*.o(.rodata*);
         *libc.a:*.o(.data*);
         src/libisagbprn.o(.rodata);
-    } =0
+    } > ROM =0
 
     multiboot_data :
     ALIGN(4)
@@ -121,19 +133,35 @@ SECTIONS {
         data/multiboot_ereader.o(.rodata);
         data/multiboot_berry_glitch_fix.o(.rodata);
         data/multiboot_pokemon_colosseum.o(.rodata);
-    } =0
+    } >ROM =0
 
     anim_mon_front_pic_data :
     ALIGN(4)
     {
         src/anim_mon_front_pics.o(.rodata);
-    } =0
+    } >ROM =0
 
     gfx_data :
     ALIGN(4)
     {
         src/graphics.o(.rodata);
-    } =0
+    } > ROM =0
+
+    .data.iwram :
+    ALIGN(4)
+    {
+        __iwram_lma = .;
+        . = . + (__iwram_end - __iwram_start);
+    } > ROM = 0
+
+    .data.ewram :
+    ALIGN(4)
+    {
+        __ewram_lma = .;
+        . = . + (__ewram_end - __ewram_start);
+    } > ROM = 0
+
+    __rom_end = .;
 
     /* DWARF debug sections.
        Symbols in the DWARF debugging sections are relative to the beginning

--- a/src/battle_anim_throw.c
+++ b/src/battle_anim_throw.c
@@ -17,6 +17,7 @@
 #include "trig.h"
 #include "util.h"
 #include "data.h"
+#include "rumble.h"
 #include "constants/items.h"
 #include "constants/moves.h"
 #include "constants/songs.h"
@@ -1144,6 +1145,7 @@ static void SpriteCB_Ball_Wobble(struct Sprite *sprite)
         gBattleSpritesDataPtr->animationData->ballSubpx = 0;
         sprite->callback = SpriteCB_Ball_Wobble_Step;
         PlaySE(SE_BALL);
+        RumbleStart();
     }
 }
 
@@ -1291,6 +1293,7 @@ static void SpriteCB_Ball_Wobble_Step(struct Sprite *sprite)
                 StartSpriteAffineAnim(sprite, BALL_ROTATE_RIGHT);
 
             PlaySE(SE_BALL);
+            RumbleStart();
         }
         break;
     }
@@ -1336,6 +1339,7 @@ static void SpriteCB_Ball_Capture_Step(struct Sprite *sprite)
     if (sprite->sTimer == 40)
     {
         PlaySE(SE_RG_BALL_CLICK);
+        SetTimedRumble(1);
         BlendPalettes(0x10000 << sprite->oam.paletteNum, 6, RGB(0, 0, 0));
         MakeCaptureStars(sprite);
     }

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -52,6 +52,7 @@
 #include "constants/songs.h"
 #include "constants/trainers.h"
 #include "tx_randomizer_and_challenges.h"
+#include "rumble.h"
 
 extern const u8 *const gBattleScriptsForMoveEffects[];
 
@@ -3038,6 +3039,7 @@ static void Cmd_tryfaintmon(void)
             gBattlescriptCurrInstr = BS_ptr;
             if (GetBattlerSide(gActiveBattler) == B_SIDE_PLAYER)
             {
+                SetTimedRumble(10);
                 gHitMarker |= HITMARKER_PLAYER_FAINTED;
                 if (gBattleResults.playerFaintCounter < 255)
                     gBattleResults.playerFaintCounter++;

--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -22,6 +22,7 @@
 #include "task.h"
 #include "tv.h"
 #include "wild_encounter.h"
+#include "rumble.h"
 #include "constants/abilities.h"
 #include "constants/event_objects.h"
 #include "constants/event_object_movement.h"
@@ -1541,6 +1542,7 @@ static bool8 PushBoulder_Move(struct Task *task, struct ObjectEvent *player, str
         gFieldEffectArguments[3] = gSprites[boulder->spriteId].oam.priority;
         FieldEffectStart(FLDEFF_DUST);
         PlaySE(SE_M_STRENGTH);
+        RumbleStart();
         task->tState++;
     }
     return FALSE;
@@ -1618,6 +1620,7 @@ static bool8 PlayerAvatar_SecretBaseMatSpinStep0(struct Task *task, struct Objec
     gPlayerAvatar.preventStep = TRUE;
     LockPlayerFieldControls();
     PlaySE(SE_WARP_IN);
+    RumbleStart();
     return TRUE;
 }
 

--- a/src/fldeff_cut.c
+++ b/src/fldeff_cut.c
@@ -22,6 +22,7 @@
 #include "constants/field_effects.h"
 #include "constants/songs.h"
 #include "constants/metatile_labels.h"
+#include "rumble.h"
 
 extern struct MapPosition gPlayerFacingPosition;
 
@@ -319,6 +320,7 @@ bool8 FldEff_CutGrass(void)
     u8 i = 0;
 
     PlaySE(SE_M_CUT);
+    RumbleStart();
     PlayerGetDestCoords(&gPlayerFacingPosition.x, &gPlayerFacingPosition.y);
     for (i = 0; i < CUT_HYPER_AREA; i++)
     {
@@ -642,6 +644,7 @@ void FixLongGrassMetatilesWindowBottom(s16 x, s16 y)
 static void StartCutTreeFieldEffect(void)
 {
     PlaySE(SE_M_CUT);
+    RumbleStart();
     FieldEffectActiveListRemove(FLDEFF_USE_CUT_ON_TREE);
     ScriptContext_Enable();
 }

--- a/src/fldeff_rocksmash.c
+++ b/src/fldeff_rocksmash.c
@@ -13,6 +13,7 @@
 #include "sound.h"
 #include "sprite.h"
 #include "task.h"
+#include "rumble.h"
 #include "constants/event_object_movement.h"
 #include "constants/event_objects.h"
 #include "constants/field_effects.h"
@@ -164,6 +165,7 @@ bool8 FldEff_UseRockSmash(void)
 static void FieldMove_RockSmash(void)
 {
     PlaySE(SE_M_ROCK_THROW);
+    RumbleStart();
     FieldEffectActiveListRemove(FLDEFF_USE_ROCK_SMASH);
     ScriptContext_Enable();
 }

--- a/src/m4a.c
+++ b/src/m4a.c
@@ -1,5 +1,7 @@
 #include <string.h>
 #include "gba/m4a_internal.h"
+#include "rumble.h"
+#include "constants/songs.h"
 
 extern const u8 gCgb3Vol[];
 
@@ -110,6 +112,27 @@ void m4aSongNumStart(u16 n)
     const struct Song *songTable = gSongTable;
     const struct Song *song = &songTable[n];
     const struct MusicPlayer *mplay = &mplayTable[song->ms];
+
+    switch (n)
+    {
+        case SE_LEDGE:
+        case SE_BIKE_BELL:
+        case SE_BIKE_HOP:
+        case SE_ICE_BREAK:
+        case SE_ICE_CRACK:
+        case SE_TRUCK_MOVE:
+        case SE_TRUCK_STOP:
+        case SE_TRUCK_UNLOAD:
+        case SE_TRUCK_DOOR:
+        case SE_ITEMFINDER:
+        case SE_BREAKABLE_DOOR:
+        case SE_FIELD_POISON:
+        case SE_M_SELF_DESTRUCT:
+        case SE_M_EXPLOSION:
+        case SE_RG_SS_ANNE_HORN:
+        case SE_POKENAV_CALL:
+            RumbleStart();
+    }
 
     MPlayStart(mplay->info, song->header);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -94,8 +94,6 @@ void EnableVCountIntrAtLine150(void);
 
 void AgbMain()
 {
-    // Modern compilers are liberal with the stack on entry to this function,
-    // so RegisterRamReset may crash if it resets IWRAM.
     *(vu16 *)BG_PLTT = RGB_WHITE; // Set the backdrop to white on startup
     InitGpuRegManager();
     REG_WAITCNT = WAITCNT_PREFETCH_ENABLE | WAITCNT_WS0_S_1 | WAITCNT_WS0_N_3;

--- a/src/main.c
+++ b/src/main.c
@@ -27,6 +27,7 @@
 #include "main_menu.h"
 #include "save.h"
 #include "new_game.h"
+#include "rumble.h"
 
 static void VBlankIntr(void);
 static void HBlankIntr(void);
@@ -130,6 +131,8 @@ void AgbMain()
 #endif
     for (;;)
     {
+        RumbleFrameUpdate();
+
         ReadKeys();
 
         if (gSoftResetDisabled == FALSE
@@ -370,6 +373,9 @@ static void VBlankIntr(void)
         Random();
 
     UpdateWirelessStatusIndicatorSprite();
+
+    if (!IsSEPlaying())
+        RumbleStop();
 
     INTR_CHECK |= INTR_FLAG_VBLANK;
     gMain.intrCheck |= INTR_FLAG_VBLANK;

--- a/src/reload_save.c
+++ b/src/reload_save.c
@@ -1,5 +1,6 @@
 #include "global.h"
 #include "main.h"
+#include "crt0.h"
 #include "gpu_regs.h"
 #include "m4a.h"
 #include "load_save.h"
@@ -15,6 +16,7 @@ void ReloadSave(void)
     u16 imeBackup = REG_IME;
     REG_IME = 0;
     RegisterRamReset(RESET_EWRAM);
+    ReInitializeEWRAM();
     ClearGpuRegBits(REG_OFFSET_DISPCNT, DISPCNT_FORCED_BLANK);
     REG_IME = imeBackup;
     gMain.inBattle = FALSE;

--- a/src/rumble.c
+++ b/src/rumble.c
@@ -1,0 +1,68 @@
+#include "global.h"
+#include "rumble.h"
+#include "main.h"
+#include "sound.h"
+
+static EWRAM_DATA u32 sRumbleState = 0;
+static EWRAM_DATA u8 sRumbleType = RUMBLE_TYPE_OFF;
+static EWRAM_DATA u32 stopRumbleVblankCounter = 0;
+
+static u16 const sNintendoHandshakeData[] = {0x494E, 0x544E, 0x4E45, 0x4F44, 0x8000};
+static void SetRumbleState(u32 state);
+
+enum
+{
+    RUMBLE_ON        = 0x40000026,
+    RUMBLE_OFF       = 0x40000004,
+    RUMBLE_HARD_STOP = 0x40000015
+};
+
+void RumbleFrameUpdate()
+{
+    REG_SIOCNT &= ~1;
+    REG_SIOCNT |= SIO_START;
+    if(gMain.vblankCounter1 == stopRumbleVblankCounter && sRumbleType == RUMBLE_TYPE_TIMED)
+        SetRumbleState(RUMBLE_OFF);
+}
+
+static void SetRumbleState(u32 state)
+{
+    sRumbleState = state;
+    if (sRumbleState != RUMBLE_ON)
+        sRumbleType = RUMBLE_TYPE_OFF;
+
+    GPIO_PORT_DIRECTION = 1 << 3;
+    GPIO_PORT_DATA = (sRumbleState == RUMBLE_ON) << 3;
+}
+
+bool32 RumbleStart(void)
+{
+    if (sRumbleType == RUMBLE_TYPE_TIMED)
+        return FALSE;
+    sRumbleType = RUMBLE_TYPE_CONT;
+    SetRumbleState(RUMBLE_ON);
+    return TRUE;
+}
+
+bool32 RumbleStop(void)
+{
+    if (sRumbleType != RUMBLE_TYPE_CONT)
+        return FALSE;
+    SetRumbleState(RUMBLE_OFF);
+    return TRUE;
+}
+
+bool32 SetTimedRumble(u8 deciseconds)
+{
+    if (sRumbleType == RUMBLE_TYPE_CONT)
+        return FALSE;
+    sRumbleType = RUMBLE_TYPE_TIMED;
+    stopRumbleVblankCounter = gMain.vblankCounter1 + (6 * deciseconds);
+    SetRumbleState(RUMBLE_ON);
+    return TRUE;
+}
+
+u32 GetRumbleState(void)
+{
+    return sRumbleState;
+}

--- a/src/siirtc.c
+++ b/src/siirtc.c
@@ -60,10 +60,6 @@
 #define DIR_ALL_IN  (DIR_0_IN | DIR_1_IN | DIR_2_IN)
 #define DIR_ALL_OUT (DIR_0_OUT | DIR_1_OUT | DIR_2_OUT)
 
-#define GPIO_PORT_DATA        (*(vu16 *)0x80000C4)
-#define GPIO_PORT_DIRECTION   (*(vu16 *)0x80000C6)
-#define GPIO_PORT_READ_ENABLE (*(vu16 *)0x80000C8)
-
 extern vu16 GPIOPortDirection;
 
 static u16 sDummy; // unused variable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds support for EZ Flash Omega DE rumble as well as DS Rumble Pak support on the Analogue Pocket.

Probably works in emulators too.

Does nothing if hardware not supported.

Original credit [devlov, Citrus Bolt](https://github.com/pret/pokeemerald/wiki/Add-In%E2%80%90Cart-Rumble).

## **Discord contact info**
`luigi___`
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
